### PR TITLE
Eased constraint for cognitive complexity

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -11,7 +11,7 @@ checks:
       threshold: 250
   method-complexity:
     config:
-      threshold: 5
+      threshold: 10
   method-count:
     config:
       threshold: 20


### PR DESCRIPTION
Cognitive complexity is something we've dealt with frequently for recent PR's. It attempts to limit the number of deeply-nested structures in our code. Since our indexedDB code is heavily dependent on working with callbacks/event handling, we decided to change the `.codeclimate.yml` config to ease this condition