### PR TITLE
Collection to collection-edit nav implemented, weekly bug fixed

### DIFF
--- a/source/html/daily.html
+++ b/source/html/daily.html
@@ -81,14 +81,12 @@
                 </form> -->
         </div>
         <div id="mid-section">
-          <a href="#" id="yesterday"
-            ><i class="fa fa-chevron-left fa-lg"></i
-          ></a>
+          <a href="#" id="yesterday">
+            <i class="fa fa-chevron-left fa-lg"></i>
+          </a>
           <!-- <button id="collapse">Collapse</button> -->
           <a href="#" id="collapse"><i class="fa fa-chevron-up fa-lg"></i></a>
-          <a href="#" id="tomorrow"
-            ><i class="fa fa-chyevron-right fa-lg"></i
-          ></a>
+          <a href="#" id="tomorrow"><i class="fa fa-chevron-right fa-lg"></i></a>
         </div>
         <div id="reflection">
           <reflection-item></reflection-item>

--- a/source/javascript/src/collection-edit.js
+++ b/source/javascript/src/collection-edit.js
@@ -96,8 +96,9 @@ function populateTasks (collection) {
  * @param {Object} JSON object containing the collection
  * surfaced from indexedDB
  */
-function populateCollectionName (collection) {
-  const name = collection.name
+function populateCollectionName () {
+  let name = window.location.hash.replace(/%20/g, " ");
+  name = name.slice(1)
   const title = document.querySelector('#title > h1')
   title.textContent = name
 }
@@ -149,9 +150,11 @@ function getLogInfoAsJSON (cb) {
     store.openCursor().onsuccess = function (event) {
       const cursor = event.target.result
       if (cursor) {
-        const collectionName = cursor.value.current_collection
+        let name = window.location.hash.slice(1)
+        name = name.replace(/%20/g, " ")
+        //const collectionName = cursor.value.current_collection
         const collection = cursor.value.properties.collections.find((element) => {
-          return element.name === collectionName
+          return element.name === name
         })
         console.log(collection)
         cb.bind(this)

--- a/source/javascript/src/collection-edit.js
+++ b/source/javascript/src/collection-edit.js
@@ -75,6 +75,7 @@ function newElement () {
  * surfaced from indexedDB
  */
 function populateTasks (collection) {
+  // console.log(collection.items)
   function createLogItem (task) {
     const logItem = document.createElement('log-item')
     logItem.itemEntry = task
@@ -97,7 +98,7 @@ function populateTasks (collection) {
  * surfaced from indexedDB
  */
 function populateCollectionName () {
-  let name = window.location.hash.replace(/%20/g, " ");
+  let name = window.location.hash.replace(/%20/g, ' ')
   name = name.slice(1)
   const title = document.querySelector('#title > h1')
   title.textContent = name
@@ -151,8 +152,8 @@ function getLogInfoAsJSON (cb) {
       const cursor = event.target.result
       if (cursor) {
         let name = window.location.hash.slice(1)
-        name = name.replace(/%20/g, " ")
-        //const collectionName = cursor.value.current_collection
+        name = name.replace(/%20/g, ' ')
+        // const collectionName = cursor.value.current_collection
         const collection = cursor.value.properties.collections.find((element) => {
           return element.name === name
         })
@@ -231,7 +232,7 @@ function insertMedia (event, media = MEDIA_TYPE.IMAGE) {
  * collection data for the collection to view
  */
 function populatePage (response) {
-  populateTasks(response)
+  // populateTasks(response)
   populateCollectionName(response)
   populateMedia(response, MEDIA_TYPE.IMAGE)
   populateMedia(response, MEDIA_TYPE.VIDEO)

--- a/source/javascript/src/components/CollectionItem.js
+++ b/source/javascript/src/components/CollectionItem.js
@@ -158,7 +158,8 @@ class CollectionItem extends HTMLElement {
       })
 
       // navigate to collection-edit page
-      window.location.href = '/source/html/collection-edit.html'
+      const url = '/source/html/collection-edit.html' + '#' + this.dataset.name
+      window.location.href = url
     })
 
     // onclick allow editing of collection name
@@ -200,6 +201,9 @@ class CollectionItem extends HTMLElement {
 
       // when user presses enter, update collection name
       form.addEventListener('submit', (event) => {
+        //FIXME: a small bug here, if user doesn't hit enter, the name won't get updated
+        //and that's because we are using the submit, maybe we should have a check mark or save button
+        //which makes the name changing process more explicit
         event.preventDefault()
         const collectionName = textInput.value
         collection.entry = { name: collectionName }

--- a/source/javascript/src/components/CollectionItem.js
+++ b/source/javascript/src/components/CollectionItem.js
@@ -201,9 +201,9 @@ class CollectionItem extends HTMLElement {
 
       // when user presses enter, update collection name
       form.addEventListener('submit', (event) => {
-        //FIXME: a small bug here, if user doesn't hit enter, the name won't get updated
-        //and that's because we are using the submit, maybe we should have a check mark or save button
-        //which makes the name changing process more explicit
+        // FIXME: a small bug here, if user doesn't hit enter, the name won't get updated
+        // and that's because we are using the submit, maybe we should have a check mark or save button
+        // which makes the name changing process more explicit
         event.preventDefault()
         const collectionName = textInput.value
         collection.entry = { name: collectionName }

--- a/source/javascript/src/utils/DateConverter.js
+++ b/source/javascript/src/utils/DateConverter.js
@@ -62,8 +62,9 @@ class DateConverter extends Date {
     // get the days correspond to _timestamp
     const that = this
     const timestampDateConverter = new DateConverter(timestamp)
+    console.log(timestampDateConverter)
     if (Math.abs(timestampDateConverter.getDaysFromTimeStamp(timestamp) - that.getDaysFromTimeStamp()) < 7) {
-      if (((that.getDay() - 1) % 7) - ((timestampDateConverter.getDay() - 1) % 7) >= 0) {
+      if (((that.getDay() + 6) % 7) - ((timestampDateConverter.getDay() + 6) % 7) >= 0) {
         return true
       }
     }
@@ -78,7 +79,7 @@ class DateConverter extends Date {
    * Monday of the current week
    */
   getBeginningOfWeek () {
-    const dayOfWeek = (this.getDay() - 1) % 7
+    const dayOfWeek = (this.getDay() + 6) % 7
     const offsetMillis = (dayOfWeek * 24 * 60 * 60 * 1000)
     const stamp = this.getTime() - offsetMillis
     return stamp

--- a/source/javascript/src/weekly.js
+++ b/source/javascript/src/weekly.js
@@ -72,7 +72,7 @@ function populateDayColumns (weeklyItems) {
     const offSet = current.getDaysFromTimeStamp(Date.now()) - current.getDaysFromTimeStamp(entry.properties.date.time)
     const currentDay = new DateConverter(Number(entry.properties.date.time))
     // apply the offset to get the index
-    const index = todayDays - offSet
+    const index = todayDays + 6 - offSet
     const weeklyItem = document.createElement('weekly-view-item')
     weeklyItem.entry = entry
     const childDiv = week.children[index]
@@ -138,6 +138,7 @@ function addColumnDates () {
     // get day offset in milliseconds
     const offsetInMillis = i * (24 * 60 * 60 * 1000)
     const currentTimestamp = mondayOfCurrentDate + offsetInMillis
+    // console.log('index ' + i + " timestamp: " + currentTimestamp)
     const currentDate = new DateConverter(currentTimestamp)
     const anchorString = `(${currentDate.getMonth() + 1}.${currentDate.getDate()})`
     anchor.textContent = `${anchor.textContent} ${anchorString}`


### PR DESCRIPTION
We are using hash url for navigation from collection to collection-edit. Collection-edit page is able to access the hash field and convert the hash into the title string. Potential bug is the user input something really weird in the title which might not be able to be represented by a hash or when converting from hash to title, some characters might get a different encoding.
For the weekly page bug, it's a logic error in the DataConverter.js. The edge case is Sunday, which when we call getDay it will return 0. If we use the logic of minus one mod seven, the day number is now 1, which pushes the weekly view into next week. I used plus six mod seven. I think we will need more test cases on this