### PR TITLE
Fixed weekly view offsetting column days

### DIFF
--- a/source/javascript/src/weekly.js
+++ b/source/javascript/src/weekly.js
@@ -56,7 +56,8 @@ function getLogInfoAsJSON (cb) {
         if (searchParams.has('displayFirstOfMonth')) {
           // gets all daily logs with the requested month and year
           result = dailyLogs.filter((log) => {
-            const timestamp = Number(log.properties.date.time) // UNIX timestamp
+            // timestamp of milliseconds since Jan 1. 1970 in local time
+            const timestamp = Number(log.properties.date.time)
             const date = new Date(timestamp)
             return (date.getFullYear() === year) && (date.getMonth() === month)
           })
@@ -103,25 +104,20 @@ function populateWeeklyView (weeklyItems, dateToCompare) {
 function populateDayColumns (weeklyItems, dateToCompare) {
   const week = document.getElementById('weekly-div')
   // create a DateConverter object
-  // Use a new instance of Date to fetch the day of the week of today
+  // Use a new instance of Date to fetch the day of the week of the given date
+  // we add six and mod by seven to shift the 0-index to start at Monday and end on Sunday.
   const compareDay = (dateToCompare.getDay() + 6) % 7
-  const today = new DateConverter()
-  let todayDays = today.getDay()
   weeklyItems.forEach((entry) => {
     // calculate the offset between today's day and the entry's day
-    const offSet = dateToCompare.getDaysFromTimeStamp() - dateToCompare.getDaysFromTimeStamp(entry.properties.date.time)
-    const currentDay = new DateConverter(Number(entry.properties.date.time))
-    // apply the offset to get the index
-    if (todayDays === 0) {
-      todayDays = 7
-    }
-    const index = todayDays - offSet
+    const currentDate = new DateConverter(Number(entry.properties.date.time))
+    const offSet = dateToCompare.getDaysFromTimeStamp() - currentDate.getDaysFromTimeStamp()
+    const index = compareDay - offSet
     const weeklyItem = document.createElement('weekly-view-item')
     weeklyItem.entry = entry
     const childDiv = week.children[index]
     // console.log(week.children[index])
     // business logic for appending the navigation link to each column
-    appendNavLinks(childDiv, currentDay)
+    appendNavLinks(childDiv, currentDate)
     childDiv.appendChild(weeklyItem)
   })
 }
@@ -139,7 +135,6 @@ document.addEventListener('DOMContentLoaded', (event) => {
  * the header for the current column on the monthly/weekly view.
  */
 function appendNavLinks (targetElement, date) {
-  // FIXME
   const anchor = targetElement.querySelector('a')
   anchor.dataset.unixTimestamp = date.getTime()
   anchor.href = '/source/html/daily.html' // @TODO refactor with routing

--- a/source/models/mock_data.json
+++ b/source/models/mock_data.json
@@ -34,40 +34,19 @@
         "properties": {
           "date": {
             "type": "string",
-            "time": "1646093520000",
+            "time": "1646078400000",
             "description": "The date of the event."
           },
           "events": [
             {
-              "description": "Saturday's event",
+              "description": "February 28, 2022",
               "logType": "event",
               "time": "1621718384658"
             }
           ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
+          "tasks": [],
+          "notes": [],
+        "reflection": [],
           "mood": {
             "type": "number",
             "multipleOf": 1,
@@ -84,40 +63,19 @@
         "properties": {
           "date": {
             "type": "string",
-            "time": "1646266320000",
+            "time": "1646251200000",
             "description": "The date of the event."
           },
           "events": [
             {
-              "description": "Saturday's event",
+              "description": "March 2, 2022",
               "logType": "event",
               "time": "1621718384658"
             }
           ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
+          "tasks": [],
+          "notes": [],
+        "reflection": [],
           "mood": {
             "type": "number",
             "multipleOf": 1,
@@ -134,290 +92,19 @@
         "properties": {
           "date": {
             "type": "string",
-            "time": "1646611920000",
+            "time": "1646510400000",
             "description": "The date of the event."
           },
           "events": [
             {
-              "description": "Saturday's event",
+              "description": "March 5, 2022",
               "logType": "event",
               "time": "1621718384658"
             }
           ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
-          "mood": {
-            "type": "number",
-            "multipleOf": 1,
-            "minimum": 0,
-            "exclusiveMaximum": 100,
-            "value": 20,
-            "description": "Daily mood on a range of 0-99."
-          }
-        }
-      },
-      {
-        "type": "object",
-        "required": [ "date", "description" ],
-        "properties": {
-          "date": {
-            "type": "string",
-            "time": "1647043920000",
-            "description": "The date of the event."
-          },
-          "events": [
-            {
-              "description": "Saturday's event",
-              "logType": "event",
-              "time": "1621718384658"
-            }
-          ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
-          "mood": {
-            "type": "number",
-            "multipleOf": 1,
-            "minimum": 0,
-            "exclusiveMaximum": 100,
-            "value": 20,
-            "description": "Daily mood on a range of 0-99."
-          }
-        }
-      },
-      {
-        "type": "object",
-        "required": [ "date", "description" ],
-        "properties": {
-          "date": {
-            "type": "string",
-            "time": "1648167120000",
-            "description": "The date of the event."
-          },
-          "events": [
-            {
-              "description": "Saturday's event",
-              "logType": "event",
-              "time": "1621718384658"
-            }
-          ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
-          "mood": {
-            "type": "number",
-            "multipleOf": 1,
-            "minimum": 0,
-            "exclusiveMaximum": 100,
-            "value": 20,
-            "description": "Daily mood on a range of 0-99."
-          }
-        }
-      },
-      {
-        "type": "object",
-        "required": [ "date", "description" ],
-        "properties": {
-          "date": {
-            "type": "string",
-            "time": "1652573520000",
-            "description": "The date of the event."
-          },
-          "events": [
-            {
-              "description": "Saturday's event",
-              "logType": "event",
-              "time": "1621718384658"
-            }
-          ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
-          "mood": {
-            "type": "number",
-            "multipleOf": 1,
-            "minimum": 0,
-            "exclusiveMaximum": 100,
-            "value": 20,
-            "description": "Daily mood on a range of 0-99."
-          }
-        }
-      },
-      {
-        "type": "object",
-        "required": [ "date", "description" ],
-        "properties": {
-          "date": {
-            "type": "string",
-            "time": "1652832720000",
-            "description": "The date of the event."
-          },
-          "events": [
-            {
-              "description": "Saturday's event",
-              "logType": "event",
-              "time": "1621718384658"
-            }
-          ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
-          "mood": {
-            "type": "number",
-            "multipleOf": 1,
-            "minimum": 0,
-            "exclusiveMaximum": 100,
-            "value": 20,
-            "description": "Daily mood on a range of 0-99."
-          }
-        }
-      },
-      {
-        "type": "object",
-        "required": [ "date", "description" ],
-        "properties": {
-          "date": {
-            "type": "string",
-            "time": "1653091920000",
-            "description": "The date of the event."
-          },
-          "events": [
-            {
-              "description": "Saturday's event",
-              "logType": "event",
-              "time": "1621718384658"
-            }
-          ],
-          "tasks": [
-              {
-                "description": "Study for midterm",
-                "logType": "task",
-                "finished": true
-              },
-              {
-                "description": "Weeknight meal prep",
-                "logType": "task",
-                "finished": false
-              }
-          ],
-          "notes": [
-            {
-              "description": "I should send a card for Jordan's birthday.",
-              "logType": "note"
-          }
-        ],
-        "reflection": [
-          {
-            "description": "Today was a good day. I got a lot of work done.",
-            "logType": "reflection"
-          }
-        ],
+          "tasks": [],
+          "notes": [],
+        "reflection": [],
           "mood": {
             "type": "number",
             "multipleOf": 1,


### PR DESCRIPTION
Once the DOM loads on `weekly.html` some of the column entries on the weekly view were not properly placed. This consequently caused some entries to not show up in addition to improperly assigned navigation links. This PR reflects changes to `populateDayColumns`, which makes comparisons/displays entries based on the reference `dateToCompare`.
Resolves #273 
Resolves #278 