### PR TITLE
Integrated routing changes with `Router.js` across all pages

### DIFF
--- a/source/html/collection-edit.html
+++ b/source/html/collection-edit.html
@@ -16,7 +16,7 @@
     <nav id="main-menu">
         <ul>
           <li >
-            <a href="./index.html" id="home">
+            <a href="./index.html" id="home" class="nav-index">
               <i class="fa fa-home fa-2x"></i>
               <span class="nav-text" >
                 Index
@@ -25,7 +25,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./search.html" class="underline">
+            <a href="./search.html" class="underline nav-search">
               <i class="fa fa-search fa-2x"></i>
               <span class="nav-text">
                 Search
@@ -34,7 +34,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./daily.html" class="underline"  >
+            <a href="./daily.html" class="underline nav-daily"  >
               <i class="fa fa-pencil fa-2x"></i>
               <span class="nav-text">
                 Daily Log
@@ -43,7 +43,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./collection.html" class="underline"  id="current">
+            <a href="./collection.html" class="underline nav-collection"  id="current">
               <i class="fa fa-folder-open fa-2x"></i>
               <span class="nav-text">
                 Collection
@@ -52,7 +52,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./weekly.html" class="underline">
+            <a href="./weekly.html" class="underline nav-weekly">
               <i class="fa fa-calendar fa-2x"></i>
               <span class="nav-text">
                 Weekly
@@ -112,5 +112,6 @@
     <script src="../javascript/src/collection-edit.js" type="module"></script>
     <script src="../javascript/src/components/LogItem.js" type="module"></script>
     <script src="../javascript/src/components/MediaItem.js" type="module"></script>
+    <script src="../javascript/src/navBar.js" type="module"></script>
 </body>
 </html>

--- a/source/html/collection.html
+++ b/source/html/collection.html
@@ -21,7 +21,7 @@
     <nav class="main-menu">
         <ul>
           <li >
-            <a href="./index.html" id="home">
+            <a href="./index.html" id="home" class="nav-index">
               <i class="fa fa-home fa-2x"></i>
               <span class="nav-text" >
                 Index
@@ -30,7 +30,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./search.html" class="underline">
+            <a href="./search.html" class="underline nav-search">
               <i class="fa fa-search fa-2x"></i>
               <span class="nav-text">
                 Search
@@ -39,7 +39,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./daily.html" class="underline"  >
+            <a href="./daily.html" class="underline nav-daily" >
               <i class="fa fa-pencil fa-2x"></i>
               <span class="nav-text">
                 Daily Log
@@ -48,7 +48,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./collection.html" class="underline"  id="current">
+            <a href="./collection.html" class="underline nav-collection"  id="current">
               <i class="fa fa-folder-open fa-2x"></i>
               <span class="nav-text">
                 Collection
@@ -57,7 +57,7 @@
     
           </li>
           <li class="has-subnav">
-            <a href="./weekly.html" class="underline">
+            <a href="./weekly.html" class="underline nav-weekly">
               <i class="fa fa-calendar fa-2x"></i>
               <span class="nav-text">
                 Weekly
@@ -86,6 +86,7 @@
     
     <script src="../javascript/src/collection.js" type="module"></script>
     <script src="../javascript/src/components/CollectionItem.js" type="module"></script>
+    <script src="../javascript/src/navBar.js" type="module"></script>
     
 </body>
 </html>

--- a/source/html/daily.html
+++ b/source/html/daily.html
@@ -136,31 +136,31 @@
     <nav class="main-menu">
       <ul>
         <li>
-          <a href="./index.html" class="underline" id="home">
+          <a href="./index.html" class="underline nav-index" id="home">
             <i class="fa fa-home fa-2x"></i>
             <span class="nav-text"> Index </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./search.html" class="underline">
+          <a href="./search.html" class="underline nav-search">
             <i class="fa fa-search fa-2x"></i>
             <span class="nav-text"> Search </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./daily.html" class="underline" id="current">
+          <a href="./daily.html" class="underline nav-daily" id="current">
             <i class="fa fa-pencil fa-2x"></i>
             <span class="nav-text"> Daily Log </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./collection.html" class="underline">
+          <a href="./collection.html" class="underline nav-collection">
             <i class="fa fa-folder-open fa-2x"></i>
             <span class="nav-text"> Collection </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./weekly.html" class="underline">
+          <a href="./weekly.html" class="underline nav-weekly">
             <i class="fa fa-calendar fa-2x"></i>
             <span class="nav-text"> Weekly </span>
           </a>
@@ -177,5 +177,7 @@
       src="../javascript/src/components/ReflectionItem.js"
       type="module"
     ></script>
+    <script src="../javascript/src/navBar.js" type="module"></script>
+
   </body>
 </html>

--- a/source/html/index.html
+++ b/source/html/index.html
@@ -48,31 +48,31 @@
     <nav class="main-menu">
       <ul>
         <li>
-          <a href="./index.html" id="current">
+          <a href="./index.html" id="current" class="nav-index">
             <i class="fa fa-home fa-2x"></i>
             <span class="nav-text"> Index </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./search.html" >
+          <a href="./search.html" class="nav-search">
             <i class="fa fa-search fa-2x"></i>
             <span class="nav-text"> Search </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./daily.html">
+          <a href="./daily.html" class="nav-daily">
             <i class="fa fa-pencil fa-2x"></i>
             <span class="nav-text"> Daily Log </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./collection.html">
+          <a href="./collection.html" class="nav-collection">
             <i class="fa fa-folder-open fa-2x"></i>
             <span class="nav-text"> Collection </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./weekly.html">
+          <a href="./weekly.html" class="nav-weekly">
             <i class="fa fa-calendar fa-2x"></i>
             <span class="nav-text"> Weekly </span>
           </a>
@@ -106,5 +106,7 @@
     <!-- <script src="../javascript/src/components/book.js" type="module"></script> -->
     <script src="../javascript/src/index.js" type="module"></script>
     <script src="../javascript/src/utils/Router.js" type="module"></script>
+    <script src="../javascript/src/navBar.js" type="module"></script>
+
 </body>
 </html>

--- a/source/html/search.html
+++ b/source/html/search.html
@@ -26,31 +26,31 @@
     <nav class="main-menu">
       <ul>
         <li>
-          <a href="./index.html" id="home" >
+          <a href="./index.html" id="home" class="nav-index">
             <i class="fa fa-home fa-2x"></i>
             <span class="nav-text"> Index </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./search.html" id="current">
+          <a href="./search.html" id="current" class="nav-search">
             <i class="fa fa-search fa-2x"></i>
             <span class="nav-text"> Search </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./daily.html">
+          <a href="./daily.html" class="nav-daily">
             <i class="fa fa-pencil fa-2x"></i>
             <span class="nav-text"> Daily Log </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./collection.html">
+          <a href="./collection.html" class="nav-collection">
             <i class="fa fa-folder-open fa-2x"></i>
             <span class="nav-text"> Collection </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./weekly.html">
+          <a href="./weekly.html" class="nav-weekly">
             <i class="fa fa-calendar fa-2x"></i>
             <span class="nav-text"> Weekly </span>
           </a>
@@ -79,7 +79,6 @@
     </form>
     <div>
         <ul id="search-results">
-          <!-- <li><search-item></search-item></li>  -->
         </ul>
     </div>
 
@@ -90,5 +89,7 @@
     <script src="../javascript/src/components/SearchItem.js" type="module"></script>
     <script src="../javascript/src/search.js" type="module"></script>
     <script src="../javascript/src/utils/Router.js" type="module"></script>
+    <script src="../javascript/src/navBar.js" type="module"></script>
+
 </body>
 </html>

--- a/source/html/weekly.html
+++ b/source/html/weekly.html
@@ -21,6 +21,8 @@
     <script src="../javascript/src/weekly.js" type="module"></script>
     <script src="../javascript/src/components/WeeklyViewItem.js" type="module"></script>
     <script src="../javascript/src/components/LogItem.js" type="module"></script>
+    <script src="../javascript/src/navBar.js" type="module"></script>
+
 </head>
 <body>
     <div class="header">
@@ -32,31 +34,31 @@
     <nav class="main-menu">
       <ul>
         <li>
-          <a href="./index.html" id="home">
+          <a href="./index.html" id="home" class="nav-index">
             <i class="fa fa-home fa-2x"></i>
             <span class="nav-text"> Index </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./search.html" class="underline">
+          <a href="./search.html" class="underline nav-search">
             <i class="fa fa-search fa-2x"></i>
             <span class="nav-text"> Search </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./daily.html" class="underline">
+          <a href="./daily.html" class="underline nav-daily">
             <i class="fa fa-pencil fa-2x"></i>
             <span class="nav-text"> Daily Log </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./collection.html" class="underline">
+          <a href="./collection.html" class="underline nav-collection">
             <i class="fa fa-folder-open fa-2x"></i>
             <span class="nav-text"> Collection </span>
           </a>
         </li>
         <li class="has-subnav">
-          <a href="./weekly.html" class="underline" id="current">
+          <a href="./weekly.html" class="underline nav-weekly" id="current">
             <i class="fa fa-calendar fa-2x"></i>
             <span class="nav-text"> Weekly </span>
           </a>

--- a/source/javascript/src/collection-edit.js
+++ b/source/javascript/src/collection-edit.js
@@ -1,6 +1,7 @@
 import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
 import { MediaItem, MEDIA_TYPE } from './components/MediaItem.js'
 import { PAGES } from './components/LogItem.js'
+import { Router } from './utils/Router.js'
 
 const collapse = document.getElementById('collapse')
 const imageBox = document.getElementById('image-collection')
@@ -33,8 +34,14 @@ function addTask (task) {
     objectStore.openCursor().onsuccess = function (event) {
       const cursor = event.target.result
       if (cursor) {
+        const router = new Router()
+        const url = router.url
         const json = cursor.value
-        const tasks = json.properties.collections[0].tasks
+        const collectionName = url.searchParams.get('name').replace(/\+/g, ' ')
+        const collection = json.properties.collections.find((collection) => {
+          return (collectionName === collection.name)
+        })
+        const tasks = collection.tasks
         const taskJson = {
           description: task,
           logType: 'task',
@@ -124,11 +131,12 @@ function populateTasks (collection) {
  * surfaced from indexedDB
  */
 function populateCollectionName () {
-  let name = window.location.hash.replace(/%20/g, ' ')
-  name = name.slice(1)
+  const router = new Router()
+  const url = router.url
+  const collectionName = url.searchParams.get('name').replace(/\+/g, ' ')
   const title = document.querySelector('#title > h1')
-  title.textContent = name
-  return name
+  title.textContent = collectionName
+  return collectionName
 }
 
 /**
@@ -194,9 +202,9 @@ function getLogInfoAsJSON (cb) {
     store.openCursor().onsuccess = function (event) {
       const cursor = event.target.result
       if (cursor) {
-        let name = window.location.hash.slice(1)
-        name = name.replace(/%20/g, ' ')
-        // const collectionName = cursor.value.current_collection
+        const router = new Router()
+        const url = router.url
+        const name = url.searchParams.get('name').replace(/\+/g, ' ')
         const collection = cursor.value.properties.collections.find((element) => {
           return element.name === name
         })

--- a/source/javascript/src/components/CollectionItem.js
+++ b/source/javascript/src/components/CollectionItem.js
@@ -1,4 +1,5 @@
 import { IndexedDBWrapper } from '../indexedDB/IndexedDBWrapper.js'
+import { Router, ROUTES } from '../utils/Router.js'
 
 // Create IndexedDB wrapper
 const wrapper = new IndexedDBWrapper('experimentalDB', 1)
@@ -142,32 +143,11 @@ class CollectionItem extends HTMLElement {
 
     // update current_collection when a collection is clicked
     this.dataset.name = this._entry.name
+    const that = this
     this.shadowRoot.querySelector('img[class="icon-collection"]').addEventListener('click', (event) => {
-      const that = this
-
-      wrapper.transaction((event) => {
-        const db = event.target.result
-
-        const transaction = db.transaction(['currentLogStore'], 'readwrite')
-        const objectStore = transaction.objectStore('currentLogStore')
-        objectStore.openCursor().onsuccess = function (event) {
-          const cursor = event.target.result
-          if (cursor) {
-            // Get JSON
-            const json = cursor.value
-
-            // Set current_collection field
-            json.current_collection = that.dataset.name
-
-            // Save changes
-            const requestUpdate = cursor.update(json)
-          }
-        }
-      })
-
-      // navigate to collection-edit page
-      const url = '/source/html/collection-edit.html' + '#' + this.dataset.name
-      window.location.href = url
+      const url = new URL(ROUTES['collection-edit'], window.location.origin)
+      url.searchParams.append('name', that.dataset.name)
+      new Router(url).navigate()
     })
 
     // onclick allow editing of collection name

--- a/source/javascript/src/components/LogItem.js
+++ b/source/javascript/src/components/LogItem.js
@@ -1,4 +1,6 @@
 import { IndexedDBWrapper } from '../indexedDB/IndexedDBWrapper.js'
+import { Router, ROUTES} from '../utils/Router.js'
+import { DateConverter } from '../utils/DateConverter.js'
 
 /**
  * Component class used in order to add individual
@@ -15,16 +17,7 @@ class LogItem extends HTMLElement {
     super()
 
     this.attachShadow({ mode: 'open' })
-    // Unfortunately this cannot be made a private field, since ESLint does not properly
-    // lint private fields.
     this._itemEntry = {}
-    /**
-     * {
-            "description": "Unfinished task for collection one",
-            "logType": "task",
-            "finished": false
-        }
-     */
     this._itemEntry.logType = 'note'
     this._itemEntry.description = ''
     this._page = 'daily'
@@ -90,37 +83,21 @@ class LogItem extends HTMLElement {
 
     const editable = this._itemEntry.editable
     /*
-     * If the entry is a task
-     * no matter if it's in weekly view or daily
-     * it will have the toggling enabled for now
-     * user can switch it from not finished to finished
-     */
-    if (this._itemEntry.logType === 'task') {
-      this.shadowRoot.querySelector('i').addEventListener('click', (event) => {
-        this._itemEntry.finished = !this._itemEntry.finished
-        this.render()
-        this.setHoverListeners()
-      })
-    }
-    /*
      * This block of code deals with the logic of editable
      * By editable we actually mean deletable
      * if editable = false, then the trash button will not show
      * Nevertheless, the user is still able to toggle the finished status
      */
+    let that = this
     if (!editable) {
-      // console.log('toggling display...')
-      // console.log(this.shadowRoot.querySelector('button'));
       this.shadowRoot.querySelector('button').style.display = 'none'
-      // console.log("not editable")
     } else {
-      // console.log("editable")
       // When dealing with log of type task, we must update the task status when it is clicked.
-      const that = this
+      that.setHoverListeners()
       if (this._itemEntry.logType === 'task') {
+        // finished/unfinished task listener
         this.shadowRoot.querySelector('i').addEventListener('click', (event) => {
           this._itemEntry.finished = !this._itemEntry.finished
-          // @TODO indexedDB transactions for check/uncheck tasks
           const wrapper = new IndexedDBWrapper('experimentalDB', 1)
 
           wrapper.transaction((event) => {
@@ -130,19 +107,30 @@ class LogItem extends HTMLElement {
             const store = transaction.objectStore('currentLogStore')
             store.openCursor().onsuccess = function (event) {
               const cursor = event.target.result
-              let collectionName,
-                collection,
-                currTask
               if (cursor) {
-                // @TODO check route to make this decision
-                switch (that._page) {
-                  case PAGES['daily-log']:
+                const router = new Router()
+                const searchParams = router.url.searchParams
+                let collectionName,
+                  collection,
+                  entry,
+                  timestamp,
+                  currTask
+                switch (router.url.pathname) {
+                  case ROUTES['daily']:
+                    timestamp = Number(searchParams.get("timestamp"))
+                    const dateConverter = new DateConverter(timestamp)
+                    entry = cursor.value.$defs['daily-logs'].find((log) => {
+                      return dateConverter.equals(Number(log.properties.date.time))
+                    })
+                    currTask = entry.properties.tasks.find((task) => {
+                      return task.description === that._itemEntry.description
+                    })
+                    currTask.finished = that._itemEntry.finished
+                    break
+                  case ROUTES['weekly']:
                     // @TODO
                     break
-                  case PAGES['weekly-view']:
-                    // @TODO
-                    break
-                  case PAGES['collection-edit']:
+                  case ROUTES['collection-edit']:
                     // find the collection with the same name
                     collectionName = cursor.value.current_collection
                     collection = cursor.value.properties.collections.find((element) => {
@@ -173,18 +161,51 @@ class LogItem extends HTMLElement {
           const transaction = db.transaction(['currentLogStore'], 'readwrite')
           const store = transaction.objectStore('currentLogStore')
           store.openCursor().onsuccess = function (event) {
+            let entryKey = (() => {
+              let returnKey
+              switch(that._itemEntry.logType) {
+                case 'task':
+                  returnKey = 'tasks'
+                  break
+                case 'note':
+                  returnKey = 'notes'
+                  break
+                case 'event':
+                  returnKey = 'events'
+                  break
+                case 'reflection':
+                  returnKey = 'reflection'
+                  break
+              }
+              return returnKey
+            })()
+
             const cursor = event.target.result
-            let collectionName,
-              collection
             if (cursor) {
-              switch (that._page) {
-                case PAGES['daily-log']:
+              const router = new Router()
+              const searchParams = router.url.searchParams
+              let collectionName,
+                collection,
+                entry,
+                logItemList,
+                timestamp,
+                currTask
+              
+              switch (router.url.pathname) {
+                case ROUTES['daily']:
+                  timestamp = Number(searchParams.get("timestamp"))
+                  const dateConverter = new DateConverter(timestamp)
+                  entry = cursor.value.$defs['daily-logs'].find((log) => {
+                    return dateConverter.equals(Number(log.properties.date.time))
+                  })
+                  entry.properties[entryKey] = entry.properties[entryKey].filter((item) => {
+                    return !(item.description === that._itemEntry.description)
+                  })
+                  break
+                case ROUTES['weekly']:
                   // @TODO
                   break
-                case PAGES['weekly-view']:
-                  // @TODO
-                  break
-                case PAGES['collection-edit']:
+                case ROUTES['collection-edit']:
                   // find the collection with the same name
                   collectionName = cursor.value.current_collection
                   collection = cursor.value.properties.collections.find((element) => {
@@ -206,9 +227,9 @@ class LogItem extends HTMLElement {
 
         this.parentElement.remove()
       })
-      // this.setHoverListeners()
     }
   }
+
 
   /*
   * Adds event listeners for all hover events on the collection item
@@ -218,11 +239,11 @@ class LogItem extends HTMLElement {
     const trashBtn = this.shadowRoot.querySelector('button')
 
     // toggles visiblity of trash icon when mouse hovers
-    this.parentElement.addEventListener('mouseenter', () => {
+    trashBtn.parentElement.addEventListener('mouseenter', () => {
       trashBtn.style.visibility = 'visible'
     })
 
-    this.parentElement.addEventListener('mouseleave', () => {
+    trashBtn.parentElement.addEventListener('mouseleave', () => {
       trashBtn.style.visibility = 'hidden'
     })
   }
@@ -237,12 +258,11 @@ class LogItem extends HTMLElement {
     // data massaging from UNIX timestamp given by key 'time'
     // to Date object given by key 'date'. This is done to reflect
     // the changes in our schema
-    if (entry.logType === 'event') {
-      entry.date = new Date(Number(entry.time))
-      delete entry.time
-    }
-    entry.editable = true
     this._itemEntry = entry
+    this._itemEntry.editable = true
+    if (entry.logType === 'event') {
+      this._itemEntry.date = new Date(Number(entry.time))
+    }
     this.render()
   }
 

--- a/source/javascript/src/components/LogItem.js
+++ b/source/javascript/src/components/LogItem.js
@@ -1,5 +1,5 @@
 import { IndexedDBWrapper } from '../indexedDB/IndexedDBWrapper.js'
-import { Router, ROUTES} from '../utils/Router.js'
+import { Router, ROUTES } from '../utils/Router.js'
 import { DateConverter } from '../utils/DateConverter.js'
 
 /**
@@ -88,7 +88,7 @@ class LogItem extends HTMLElement {
      * if editable = false, then the trash button will not show
      * Nevertheless, the user is still able to toggle the finished status
      */
-    let that = this
+    const that = this
     if (!editable) {
       this.shadowRoot.querySelector('button').style.display = 'none'
     } else {
@@ -110,15 +110,16 @@ class LogItem extends HTMLElement {
               if (cursor) {
                 const router = new Router()
                 const searchParams = router.url.searchParams
+                let dateConverter
                 let collectionName,
                   collection,
                   entry,
                   timestamp,
                   currTask
                 switch (router.url.pathname) {
-                  case ROUTES['daily']:
-                    timestamp = Number(searchParams.get("timestamp"))
-                    const dateConverter = new DateConverter(timestamp)
+                  case ROUTES.daily:
+                    timestamp = Number(searchParams.get('timestamp'))
+                    dateConverter = new DateConverter(timestamp)
                     entry = cursor.value.$defs['daily-logs'].find((log) => {
                       return dateConverter.equals(Number(log.properties.date.time))
                     })
@@ -127,12 +128,12 @@ class LogItem extends HTMLElement {
                     })
                     currTask.finished = that._itemEntry.finished
                     break
-                  case ROUTES['weekly']:
+                  case ROUTES.weekly:
                     // @TODO
                     break
                   case ROUTES['collection-edit']:
                     // find the collection with the same name
-                    collectionName = cursor.value.current_collection
+                    collectionName = searchParams.get('name').replace(/\+/g, ' ')
                     collection = cursor.value.properties.collections.find((element) => {
                       return element.name === collectionName
                     })
@@ -161,9 +162,9 @@ class LogItem extends HTMLElement {
           const transaction = db.transaction(['currentLogStore'], 'readwrite')
           const store = transaction.objectStore('currentLogStore')
           store.openCursor().onsuccess = function (event) {
-            let entryKey = (() => {
+            const entryKey = (() => {
               let returnKey
-              switch(that._itemEntry.logType) {
+              switch (that._itemEntry.logType) {
                 case 'task':
                   returnKey = 'tasks'
                   break
@@ -184,17 +185,18 @@ class LogItem extends HTMLElement {
             if (cursor) {
               const router = new Router()
               const searchParams = router.url.searchParams
+              let dateConverter
               let collectionName,
                 collection,
                 entry,
                 logItemList,
                 timestamp,
                 currTask
-              
+
               switch (router.url.pathname) {
-                case ROUTES['daily']:
-                  timestamp = Number(searchParams.get("timestamp"))
-                  const dateConverter = new DateConverter(timestamp)
+                case ROUTES.daily:
+                  timestamp = Number(searchParams.get('timestamp'))
+                  dateConverter = new DateConverter(timestamp)
                   entry = cursor.value.$defs['daily-logs'].find((log) => {
                     return dateConverter.equals(Number(log.properties.date.time))
                   })
@@ -202,12 +204,12 @@ class LogItem extends HTMLElement {
                     return !(item.description === that._itemEntry.description)
                   })
                   break
-                case ROUTES['weekly']:
+                case ROUTES.weekly:
                   // @TODO
                   break
                 case ROUTES['collection-edit']:
                   // find the collection with the same name
-                  collectionName = cursor.value.current_collection
+                  collectionName = searchParams.get('name').replace(/\+/g, ' ')
                   collection = cursor.value.properties.collections.find((element) => {
                     return element.name === collectionName
                   })
@@ -229,7 +231,6 @@ class LogItem extends HTMLElement {
       })
     }
   }
-
 
   /*
   * Adds event listeners for all hover events on the collection item

--- a/source/javascript/src/components/MediaItem.js
+++ b/source/javascript/src/components/MediaItem.js
@@ -1,4 +1,5 @@
 import { IndexedDBWrapper } from '../indexedDB/IndexedDBWrapper.js'
+import { Router, ROUTES } from '../utils/Router.js'
 
 const MEDIA_TYPE = {
   IMAGE: 0,
@@ -100,7 +101,9 @@ class MediaItem extends HTMLElement {
         store.openCursor().onsuccess = function (event) {
           const cursor = event.target.result
           if (cursor) {
-            const collectionName = cursor.value.current_collection
+            const router = new Router()
+            const params = router.url.searchParams
+            const collectionName = params.get('name').replace(/\+/g, ' ')
             const collection = cursor.value.properties.collections.find((element) => {
               return element.name === collectionName
             })

--- a/source/javascript/src/components/ReflectionItem.js
+++ b/source/javascript/src/components/ReflectionItem.js
@@ -1,5 +1,6 @@
 import { IndexedDBWrapper } from '../indexedDB/IndexedDBWrapper.js'
 import { DateConverter } from '../utils/DateConverter.js'
+import { Router, ROUTES } from '../utils/Router.js'
 
 /**
  * Component class for creating the reflection field
@@ -104,10 +105,12 @@ class ReflectionItem extends HTMLElement {
         store.openCursor().onsuccess = function (event) {
           const cursor = event.target.result
           if (cursor) {
-            console.log(cursor.value)
             // current Log we are viewing
-            const currentLog = cursor.value.current_log
-            const dateConverter = new DateConverter(Number(currentLog))
+            const router = new Router()
+            const searchParams = router.url.searchParams
+            
+            const timestamp = Number(searchParams.get('timestamp'))
+            const dateConverter = new DateConverter(timestamp)
             cursor.value.$defs['daily-logs'].forEach((log, index) => {
               // check if we indexed the correct daily log to change
               if (dateConverter.equals(Number(log.properties.date.time))) {

--- a/source/javascript/src/components/ReflectionItem.js
+++ b/source/javascript/src/components/ReflectionItem.js
@@ -108,7 +108,7 @@ class ReflectionItem extends HTMLElement {
             // current Log we are viewing
             const router = new Router()
             const searchParams = router.url.searchParams
-            
+
             const timestamp = Number(searchParams.get('timestamp'))
             const dateConverter = new DateConverter(timestamp)
             cursor.value.$defs['daily-logs'].forEach((log, index) => {

--- a/source/javascript/src/components/SearchItem.js
+++ b/source/javascript/src/components/SearchItem.js
@@ -63,10 +63,8 @@ class SearchItem extends HTMLElement {
     } else {
       this.shadowRoot.querySelector('a').addEventListener('click', (event) => {
         event.preventDefault()
-        const params = new URLSearchParams()
-        params.append('name', encodeURIComponent(that._entry.name))
         const url = new URL(ROUTES['collection-edit'], window.location.origin)
-        url.search = params
+        url.searchParams.append('name', encodeURIComponent(that._entry.name.trim()))
         new Router(url).navigate()
       })
       this.populateCollectionTasks()

--- a/source/javascript/src/components/SearchItem.js
+++ b/source/javascript/src/components/SearchItem.js
@@ -64,7 +64,7 @@ class SearchItem extends HTMLElement {
       this.shadowRoot.querySelector('a').addEventListener('click', (event) => {
         event.preventDefault()
         const url = new URL(ROUTES['collection-edit'], window.location.origin)
-        url.searchParams.append('name', encodeURIComponent(that._entry.name.trim()))
+        url.searchParams.append('name', that._entry.name)
         new Router(url).navigate()
       })
       this.populateCollectionTasks()

--- a/source/javascript/src/components/book.js
+++ b/source/javascript/src/components/book.js
@@ -79,13 +79,6 @@ class Book extends HTMLElement {
 
   makeClickable () {
     this.addEventListener('click', () => {
-      console.log('book clicked')
-      /**
-       * we need the month
-       * we need the year
-       * [RELATIVE URL]?displayFirstOfMonth=true
-       */
-
       // Get month and year of the clicked book
       const month = this.title
       const year = this.shelf

--- a/source/javascript/src/components/tag.js
+++ b/source/javascript/src/components/tag.js
@@ -1,3 +1,5 @@
+import { DateConverter } from '../utils/DateConverter.js'
+import { Router } from '../utils/Router.js'
 import { wrapper } from './CollectionItem.js'
 
 const template = document.createElement('template')
@@ -72,24 +74,32 @@ class Tag extends HTMLElement {
   removeCollectionTag (collectionName) {
     wrapper.transaction((event) => {
       const db = event.target.result
-
       const transaction = db.transaction(['currentLogStore'], 'readwrite')
       const objectStore = transaction.objectStore('currentLogStore')
       objectStore.openCursor().onsuccess = function (event) {
         const cursor = event.target.result
-
+        
         if (cursor) {
           const json = cursor.value
           const collections = json.properties.collections
-          const currentLog = json.current_log
-
+          const router = new Router()
+          const params = router.url.searchParams
+          const dateConverter = new DateConverter(Number(params.get('timestamp')))
+          const currentLog = dateConverter.timestamp
+          let findLog = (collection) => {
+            return collection.find((log) => {
+              return dateConverter.equals(new DateConverter(log))
+            })
+          }
+          
           collections.forEach(collection => {
             if (collection.name === collectionName) {
-              const index = collection.logs.indexOf(currentLog)
-              collection.logs.splice(index, 1)
+              const index = findLog(collection.log)
+              if(!(index === undefined)) {
+                collection.logs.splice(index, 1)
+              }
             }
           })
-
           cursor.update(json)
         }
       }

--- a/source/javascript/src/components/tag.js
+++ b/source/javascript/src/components/tag.js
@@ -87,14 +87,14 @@ class Tag extends HTMLElement {
           const dateConverter = new DateConverter(Number(params.get('timestamp')))
           const currentLog = dateConverter.timestamp
           const findLog = (collection) => {
-            return collection.find((log) => {
+            return collection.findIndex((log) => {
               return dateConverter.equals(new DateConverter(log))
             })
           }
 
           collections.forEach(collection => {
             if (collection.name === collectionName) {
-              const index = findLog(collection.log)
+              const index = findLog(collection.logs)
               if (!(index === undefined)) {
                 collection.logs.splice(index, 1)
               }

--- a/source/javascript/src/components/tag.js
+++ b/source/javascript/src/components/tag.js
@@ -78,7 +78,7 @@ class Tag extends HTMLElement {
       const objectStore = transaction.objectStore('currentLogStore')
       objectStore.openCursor().onsuccess = function (event) {
         const cursor = event.target.result
-        
+
         if (cursor) {
           const json = cursor.value
           const collections = json.properties.collections
@@ -86,16 +86,16 @@ class Tag extends HTMLElement {
           const params = router.url.searchParams
           const dateConverter = new DateConverter(Number(params.get('timestamp')))
           const currentLog = dateConverter.timestamp
-          let findLog = (collection) => {
+          const findLog = (collection) => {
             return collection.find((log) => {
               return dateConverter.equals(new DateConverter(log))
             })
           }
-          
+
           collections.forEach(collection => {
             if (collection.name === collectionName) {
               const index = findLog(collection.log)
-              if(!(index === undefined)) {
+              if (!(index === undefined)) {
                 collection.logs.splice(index, 1)
               }
             }

--- a/source/javascript/src/daily.js
+++ b/source/javascript/src/daily.js
@@ -73,6 +73,7 @@ collapse.addEventListener('click', () => {
 
 tagOptions.addEventListener('click', (event) => {
   const collectionName = event.target.textContent
+  console.log('clicked!')
   document.querySelector('.tags').append(new Tag(collectionName))
   addCollectionTag(collectionName)
 })
@@ -90,7 +91,7 @@ function addCollectionTag (collectionName) {
         const json = cursor.value
         const collections = json.properties.collections
         const router = new Router()
-        const params = router.url.params
+        const params = router.url.searchParams
         const timestamp = Number(params.get('timestamp'))
 
         collections.forEach(collection => {
@@ -395,7 +396,7 @@ function setTagOptions (json) {
 
   collections.forEach(collection => {
     // only add option if daily log doesn't already belong to the collection
-    if (containsLog(collection.logs)) {
+    if (!containsLog(collection.logs)) {
       const anchor = document.createElement('a')
       anchor.setAttribute('href', '#')
       anchor.textContent = collection.name

--- a/source/javascript/src/daily.js
+++ b/source/javascript/src/daily.js
@@ -1,8 +1,7 @@
 import { wrapper } from './components/CollectionItem.js'
 import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
 import { DateConverter } from './utils/DateConverter.js'
-// import { LogItem } from './components/LogItem.js'
-// having issues using LogItem - I think there's no export in the js
+import { Router, ROUTES } from './utils/Router.js'
 import { Tag } from './components/tag.js'
 
 const collapse = document.getElementById('collapse')
@@ -27,24 +26,6 @@ cancelBtn.addEventListener('click', () => {
   // TODO: implement hide functionality
   text.value = ''
 })
-
-/*
- * This onclick toggles the display style of the quote to none
- * TODO: Collapse the whole div, not just the quote
- * Resource: https://codepen.io/Mdade89/pen/JKkYGq
- * the link above provides a collapsible text box
- */
-// document.addEventListener('DOMContentLoaded', () => {
-//   saveBtn.style.visibility = 'hidden'
-//   saveBtn.addEventListener('click', (event) => {
-//     event.preventDefault()
-//     newElement()
-//   })
-//   cancelBtn.style.visibility = 'hidden'
-//   text.type = 'hidden'
-//   date.type = 'hidden'
-//   time.type = 'hidden'
-// })
 
 radioContainer.addEventListener('change', () => {
   resetEverything()
@@ -108,11 +89,13 @@ function addCollectionTag (collectionName) {
       if (cursor) {
         const json = cursor.value
         const collections = json.properties.collections
-        const currentLog = json.current_log
+        const router = new Router()
+        const params = router.url.params
+        const timestamp = Number(params.get('timestamp'))
 
         collections.forEach(collection => {
           if (collection.name === collectionName) {
-            collection.logs.push(currentLog)
+            collection.logs.push(timestamp)
           }
         })
 
@@ -221,41 +204,21 @@ function updateElement (logEntry, entry) {
       const cursor = event.target.result
       if (cursor) {
         // Get the cursor value and push the log item entry onto the file
-        const json = cursor.value
-        const dailyLog = json.$defs['daily-logs'][0].properties[entry]
-        dailyLog.push(logEntry)
-        const updated = cursor.update(cursor.value)
-
-        // Error of adding data
-        updated.onerror = function (event) {
-          console.log('ERROR: unable to add data')
+        const router = new Router()
+        const searchParams = router.url.searchParams
+        if(searchParams.has('timestamp')) {
+          const timestamp = Number(searchParams.get('timestamp'))
+          const dateConverter = new DateConverter(timestamp)
+          cursor.value.$defs['daily-logs'].forEach((log, index) => {
+            if (dateConverter.equals(Number(log.properties.date.time))) {
+              cursor.value.$defs['daily-logs'][index].properties[entry].push(logEntry)
+            }
+          })
         }
-
-        // Data got successfully added
-        updated.onsuccess = function (event) {
-          console.log('Successfully added data')
-        }
+        cursor.update(cursor.value)
       }
     }
   })
-
-  // const itemEntry = {}
-  // // Check if log type is task
-  // if (logType === 'task') {
-  //   itemEntry.logType = logType
-  //   itemEntry.finished = update
-  //   // put() method will update the record in the db if it exists
-  //   store.put(itemEntry)
-  // }
-
-  // // Check if we instead just want to delete the task/note/event
-  // if (update === 'delete') {
-  //   store.delete(key)
-  // }
-
-  // Get task/note/event from the parameter entry
-  // Create transaction to delete
-  // Delete transaction
 }
 
 /**
@@ -282,47 +245,53 @@ function getLogInfoAsJSON (cb) {
     store.openCursor().onsuccess = function (event) {
       const cursor = event.target.result
       if (cursor) {
-        const dateConverter = new DateConverter(Number(cursor.value.current_log))
-        // console.log(cursor.value)
-        let match = false
-        let lenArr = 0
-        cursor.value.$defs['daily-logs'].forEach((log, index) => {
-          if (dateConverter.equals(Number(log.properties.date.time))) {
-            match = true
-            cb.bind(this)
-            cb(cursor.value.$defs['daily-logs'][index], cursor.value)
-          }
-          lenArr = index
-        })
-        if (!match) {
-          const dlLength = cursor.value.$defs['daily-logs']
-          const appendObj = {
-            type: 'object',
-            required: ['date', 'description'],
-            properties: {
-              date: {
-                type: 'string',
-                time: cursor.value.current_log,
-                description: 'The date of the event.'
-              },
-              events: [],
-              tasks: [],
-              notes: [],
-              reflection: [],
-              mood: {
-                type: 'number',
-                multipleOf: 1,
-                minimum: 0,
-                exclusiveMaximum: 100,
-                value: 50,
-                description: 'Daily mood on a range of 0-99.'
+        const router = new Router()
+        const searchParams = router.url.searchParams
+        if(searchParams.has('timestamp')) {
+          const timestamp = Number(searchParams.get('timestamp'))
+          const dateConverter = new DateConverter(timestamp)
+          // console.log(cursor.value)
+          let match = false
+          let lenArr = 0
+          cursor.value.$defs['daily-logs'].forEach((log, index) => {
+            if (dateConverter.equals(Number(log.properties.date.time))) {
+              match = true
+              cb.bind(this)
+              cb(cursor.value.$defs['daily-logs'][index], cursor.value)
+            }
+            lenArr = index
+          })
+          // if there is no match for the given day, we create a daily log
+          if (!match) {
+            const dlLength = cursor.value.$defs['daily-logs']
+            const appendObj = {
+              type: 'object',
+              required: ['date', 'description'],
+              properties: {
+                date: {
+                  type: 'string',
+                  time: timestamp,
+                  description: 'The date of the event.'
+                },
+                events: [],
+                tasks: [],
+                notes: [],
+                reflection: [],
+                mood: {
+                  type: 'number',
+                  multipleOf: 1,
+                  minimum: 0,
+                  exclusiveMaximum: 100,
+                  value: 50,
+                  description: 'Daily mood on a range of 0-99.'
+                }
               }
             }
+            cursor.value.$defs['daily-logs'].push(appendObj)
+            cb.bind(this)
+            cb(cursor.value.$defs['daily-logs'][lenArr + 1], cursor.value)
+            cursor.update(cursor.value)
           }
-          cursor.value.$defs['daily-logs'].push(appendObj)
-          cb.bind(this)
-          cb(cursor.value.$defs['daily-logs'][lenArr + 1], cursor.value)
-          cursor.update(cursor.value)
         }
       }
     }
@@ -349,7 +318,6 @@ function setEntries (log) {
       li.appendChild(logItem)
       logItem.setHoverListeners()
       document.getElementById('myUL').appendChild(li)
-      console.log('Adding entries for ' + logItem.itemEntry)
     })
   }
 
@@ -357,6 +325,7 @@ function setEntries (log) {
   populateTypeOfEntry(log.properties.tasks)
   populateTypeOfEntry(log.properties.notes)
   populateTypeOfEntry(log.properties.events)
+  populateTypeOfEntry(log.properties.reflection)
 }
 
 /**
@@ -390,13 +359,19 @@ function setDate (log) {
 
 function setTags (json) {
   const collections = json.properties.collections
-  const currentLog = json.current_log
+  const router = new Router()
+  const params = router.url.searchParams
+  const dateConverter = new DateConverter(Number(params.get('timestamp')))
+  const currentLog = dateConverter.timestamp
+
+  let containsLog = (collection) => {
+    return !(collection.find((log) => {
+      return dateConverter.equals(new DateConverter(log))
+    }) === undefined)
+  }
 
   collections.forEach(collection => {
-    const logs = collection.logs
-
-    // if collection has current currentLog
-    if (logs.indexOf(currentLog) !== -1) {
+    if(containsLog(collection.logs)) {
       document.querySelector('.tags').append(new Tag(collection.name))
     }
   })
@@ -404,15 +379,23 @@ function setTags (json) {
 
 function setTagOptions (json) {
   const collections = json.properties.collections
-  const currentLog = json.current_log
+  const router = new Router()
+  const params = router.url.searchParams
+  const dateConverter = new DateConverter(Number(params.get('timestamp')))
+  const currentLog = dateConverter.timestamp
+
   const tagOptions = document.querySelector('.tag-options')
   tagOptions.innerHTML = ''
 
-  collections.forEach(collection => {
-    const logs = collection.logs
+  let containsLog = (collection) => {
+    return !(collection.find((log) => {
+      return dateConverter.equals(new DateConverter(log))
+    }) === undefined)
+  }
 
+  collections.forEach(collection => {
     // only add option if daily log doesn't already belong to the collection
-    if (logs.indexOf(currentLog) === -1) {
+    if(containsLog(collection.logs)) {
       const anchor = document.createElement('a')
       anchor.setAttribute('href', '#')
       anchor.textContent = collection.name
@@ -446,11 +429,11 @@ function populateDailyLog (response, json) {
  * @author Noah Teshima <nteshima@ucsd.edu>
  * @param {Number} timestamp Number object representing our
  * UNIX timestamp
- * @returns {Date} Date object containing the date contained
+ * @returns {DateConverter} DateConverter object containing the date contained
  * in the UNIX timestamp.
  */
 function getDateFromUNIXTimestamp (timestamp) {
-  return new Date(timestamp)
+  return new DateConverter(timestamp)
 }
 
 document.addEventListener('DOMContentLoaded', (event) => {
@@ -461,65 +444,32 @@ document.addEventListener('DOMContentLoaded', (event) => {
   getLogInfoAsJSON(populateDailyLog)
 })
 
-// const zoom = document.getElementById('pretty')
-// const custZoom = document.getElementById('button1')
-
-// custZoom.addEventListener('click', function () {
-//   zoom.click()
-// })
+const yesterdayTodayNav = (yesterday = true) => {
+  const router = new Router()
+  const searchParams = router.url.searchParams
+  if(searchParams.has('timestamp')) {
+    const timestamp = Number(searchParams.get('timestamp'))
+    searchParams.set('timestamp', yesterday ? timestamp - 86400000 : timestamp + 86400000)
+    router.navigate()
+  }
+}
 
 /**
  * Business logic for tommorow Button
  * @author Brett Herbst <bherbst@ucsd.edu>
+ * @author Noah Teshima <nteshima@ucsd.edu>
  * Modeled after index.js Rapid Log button
  */
 tmButton.addEventListener('click', () => {
-  const wrapper = new IndexedDBWrapper('experimentalDB', 1)
-  wrapper.transaction((event) => {
-    const db = event.target.result
-
-    const transaction = db.transaction(['currentLogStore'], 'readwrite')
-
-    const store = transaction.objectStore('currentLogStore')
-    const req = store.openCursor()
-    // Fires when cursor is successfully opened.
-    req.onsuccess = function (e) {
-      const cursor = e.target.result
-      if (cursor) {
-        // Iterates current_log forward 1 day
-        cursor.value.current_log = (parseInt(cursor.value.current_log) + 86400000).toString()
-        cursor.update(cursor.value)
-      }
-      getLogInfoAsJSON(populateDailyLog)
-    }
-  })
+  yesterdayTodayNav(false)
 })
 
 /**
  * Business logic for yesterday Button
  * @author Brett Herbst <bherbst@ucsd.edu>
+ * @author Noah Teshima <nteshima@ucsd.edu>
  * Modeled after index.js Rapid Log button
  */
 ytButton.addEventListener('click', () => {
-  const wrapper = new IndexedDBWrapper('experimentalDB', 1)
-  wrapper.transaction((event) => {
-    const db = event.target.result
-
-    const transaction = db.transaction(['currentLogStore'], 'readwrite')
-    // Event triggered when transaction is successfully opened
-
-    const store = transaction.objectStore('currentLogStore')
-
-    const req = store.openCursor()
-    // Fires when cursor is successfully opened.
-    req.onsuccess = function (e) {
-      const cursor = e.target.result
-      if (cursor) {
-        // Iterates current_log back 1 day
-        cursor.value.current_log = (parseInt(cursor.value.current_log) - 86400000).toString()
-        cursor.update(cursor.value)
-      }
-      getLogInfoAsJSON(populateDailyLog)
-    }
-  })
+  yesterdayTodayNav(true)
 })

--- a/source/javascript/src/daily.js
+++ b/source/javascript/src/daily.js
@@ -206,7 +206,7 @@ function updateElement (logEntry, entry) {
         // Get the cursor value and push the log item entry onto the file
         const router = new Router()
         const searchParams = router.url.searchParams
-        if(searchParams.has('timestamp')) {
+        if (searchParams.has('timestamp')) {
           const timestamp = Number(searchParams.get('timestamp'))
           const dateConverter = new DateConverter(timestamp)
           cursor.value.$defs['daily-logs'].forEach((log, index) => {
@@ -247,7 +247,7 @@ function getLogInfoAsJSON (cb) {
       if (cursor) {
         const router = new Router()
         const searchParams = router.url.searchParams
-        if(searchParams.has('timestamp')) {
+        if (searchParams.has('timestamp')) {
           const timestamp = Number(searchParams.get('timestamp'))
           const dateConverter = new DateConverter(timestamp)
           // console.log(cursor.value)
@@ -364,14 +364,14 @@ function setTags (json) {
   const dateConverter = new DateConverter(Number(params.get('timestamp')))
   const currentLog = dateConverter.timestamp
 
-  let containsLog = (collection) => {
+  const containsLog = (collection) => {
     return !(collection.find((log) => {
       return dateConverter.equals(new DateConverter(log))
     }) === undefined)
   }
 
   collections.forEach(collection => {
-    if(containsLog(collection.logs)) {
+    if (containsLog(collection.logs)) {
       document.querySelector('.tags').append(new Tag(collection.name))
     }
   })
@@ -387,7 +387,7 @@ function setTagOptions (json) {
   const tagOptions = document.querySelector('.tag-options')
   tagOptions.innerHTML = ''
 
-  let containsLog = (collection) => {
+  const containsLog = (collection) => {
     return !(collection.find((log) => {
       return dateConverter.equals(new DateConverter(log))
     }) === undefined)
@@ -395,7 +395,7 @@ function setTagOptions (json) {
 
   collections.forEach(collection => {
     // only add option if daily log doesn't already belong to the collection
-    if(containsLog(collection.logs)) {
+    if (containsLog(collection.logs)) {
       const anchor = document.createElement('a')
       anchor.setAttribute('href', '#')
       anchor.textContent = collection.name
@@ -447,7 +447,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 const yesterdayTodayNav = (yesterday = true) => {
   const router = new Router()
   const searchParams = router.url.searchParams
-  if(searchParams.has('timestamp')) {
+  if (searchParams.has('timestamp')) {
     const timestamp = Number(searchParams.get('timestamp'))
     searchParams.set('timestamp', yesterday ? timestamp - 86400000 : timestamp + 86400000)
     router.navigate()

--- a/source/javascript/src/index.js
+++ b/source/javascript/src/index.js
@@ -4,7 +4,6 @@ import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
 import { Shelf } from './components/Shelf.js'
 import { Book } from './components/Book.js'
 
-
 document.addEventListener('DOMContentLoaded', (event) => {
   const addDailyLog = document.getElementById('cb')
 

--- a/source/javascript/src/index.js
+++ b/source/javascript/src/index.js
@@ -1,62 +1,23 @@
 import { DateConverter } from './utils/DateConverter.js'
+import { Router, ROUTES } from './utils/Router.js'
 import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
 import { Shelf } from './components/Shelf.js'
 import { Book } from './components/Book.js'
 
-// const realAdd = document.getElementById('rapid-log')
-// const custADD = document.getElementById('cb')
-// document.addEventListener('click', function () {
-//   realAdd.click()
-// })
 
 document.addEventListener('DOMContentLoaded', (event) => {
   const addDailyLog = document.getElementById('cb')
 
   addDailyLog.onclick = function (event) {
-    // Allows us to make write transactions before navigating
     event.preventDefault()
     const wrapper = new IndexedDBWrapper('experimentalDB', 1)
-    wrapper.transaction((event) => {
-      const db = event.target.result
-
-      const transaction = db.transaction(['currentLogStore'], 'readwrite')
-      // Event triggered when transaction is successfully opened
-      transaction.oncomplete = (event) => {
-        console.log('Transaction completed.')
-      }
-
-      transaction.onerror = (event) => {
-        console.log('Transaction error.')
-      }
-
-      transaction.onsuccess = (event) => {
-        console.log('Transaction succeeded.')
-      }
-
-      const store = transaction.objectStore('currentLogStore')
-
-      const req = store.openCursor()
-      // Fires when cursor is successfully opened.
-      req.onsuccess = function (e) {
-        const cursor = e.target.result
-        if (cursor) {
-          console.log(cursor.value.current_log)
-          cursor.value.current_log = String(Date.now())
-          cursor.update(cursor.value)
-        } else {
-          // This block of execution occurs if we have no entries set up under
-          // object storage (i.e. new user who clicked on 'Add+')
-          const tempObjectStore = db.transaction(['currentLogStore'], 'readwrite')
-            .objectStore('currentLogStore')
-          wrapper.addNewLog(event, true) // @TODO
-          console.log('Made new entry!')
-        }
-        // Unsuspend navigation
-        window.location.href = 'daily.html'
-      }
-    })
+    const params = new URLSearchParams()
+    params.append('timestamp', (new DateConverter()).timestamp)
+    const url = new URL(ROUTES.daily, location.origin)
+    url.search = params
+    new Router(url).navigate()
   }
-})// .call(this)
+})
 
 const shelves = document.getElementsByTagName('book-shelf')
 

--- a/source/javascript/src/indexedDB/IndexedDBWrapper.js
+++ b/source/javascript/src/indexedDB/IndexedDBWrapper.js
@@ -20,7 +20,6 @@ class IndexedDBWrapper {
   constructor (dbName, version) {
     this._dbName = dbName
     this._version = version
-    console.log('initialized indexedDBWrapper')
   }
 
   /**

--- a/source/javascript/src/navBar.js
+++ b/source/javascript/src/navBar.js
@@ -2,7 +2,6 @@ import { DateConverter } from './utils/DateConverter.js'
 import { Router, ROUTES } from './utils/Router.js'
 import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
 
-
 document.addEventListener('DOMContentLoaded', (event) => {
   const indexNavButton = document.querySelector('.nav-index')
   const searchNavButton = document.querySelector('.nav-search')
@@ -10,7 +9,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
   const collectionNavButton = document.querySelector('.nav-collection')
   const weeklyNavButton = document.querySelector('.nav-weekly')
 
-  let defaultNav = (route, params = new URLSearchParams()) => {
+  const defaultNav = (route, params = new URLSearchParams()) => {
     const url = new URL(route, location.origin)
     url.search = params
     new Router(url).navigate()
@@ -28,7 +27,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
   dailyNavButton.addEventListener('click', (event) => {
     event.preventDefault()
-    let params = new URLSearchParams()
+    const params = new URLSearchParams()
     params.append('timestamp', (new DateConverter()).timestamp)
     defaultNav(ROUTES.daily, params)
   })
@@ -43,4 +42,3 @@ document.addEventListener('DOMContentLoaded', (event) => {
     defaultNav(ROUTES.weekly)
   })
 })
-

--- a/source/javascript/src/navBar.js
+++ b/source/javascript/src/navBar.js
@@ -1,0 +1,46 @@
+import { DateConverter } from './utils/DateConverter.js'
+import { Router, ROUTES } from './utils/Router.js'
+import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
+
+
+document.addEventListener('DOMContentLoaded', (event) => {
+  const indexNavButton = document.querySelector('.nav-index')
+  const searchNavButton = document.querySelector('.nav-search')
+  const dailyNavButton = document.querySelector('.nav-daily')
+  const collectionNavButton = document.querySelector('.nav-collection')
+  const weeklyNavButton = document.querySelector('.nav-weekly')
+
+  let defaultNav = (route, params = new URLSearchParams()) => {
+    const url = new URL(route, location.origin)
+    url.search = params
+    new Router(url).navigate()
+  }
+
+  indexNavButton.addEventListener('click', (event) => {
+    event.preventDefault()
+    defaultNav(ROUTES.index)
+  })
+
+  searchNavButton.addEventListener('click', (event) => {
+    event.preventDefault()
+    defaultNav(ROUTES.search)
+  })
+
+  dailyNavButton.addEventListener('click', (event) => {
+    event.preventDefault()
+    let params = new URLSearchParams()
+    params.append('timestamp', (new DateConverter()).timestamp)
+    defaultNav(ROUTES.daily, params)
+  })
+
+  collectionNavButton.addEventListener('click', (event) => {
+    event.preventDefault()
+    defaultNav(ROUTES.collections)
+  })
+
+  weeklyNavButton.addEventListener('click', (event) => {
+    event.preventDefault()
+    defaultNav(ROUTES.weekly)
+  })
+})
+

--- a/source/javascript/src/search.js
+++ b/source/javascript/src/search.js
@@ -120,59 +120,6 @@ const inputField = document.getElementById('input-area')
 const radioDailyLog = document.getElementById('input1')
 const radioCollection = document.getElementById('input2')
 document.addEventListener('DOMContentLoaded', (event) => {
-  const searchItem = document.createElement('search-item')
-  const li = document.createElement('li')
-  const searchItem2 = document.createElement('search-item')
-  const li2 = document.createElement('li')
-  searchItem.entry = {
-    time: Date.now(),
-    tasks: [{
-      item: {
-        description: 'I have a midterm coming up',
-        logType: 'task',
-        finished: true
-      }
-    }],
-    notes: [{
-      item: {
-        description: 'I did good on the midterm',
-        logType: 'note'
-      }
-    }],
-    events: [],
-    reflection: [],
-    type: 'daily-log'
-  }
-  searchItem2.entry = {
-    time: Date.now(),
-    tasks: [{
-      item: {
-        description: 'The midterm yesterday was really difficult tbh',
-        logType: 'task',
-        finished: true
-      }
-    },
-    {
-      item: {
-        description: 'Study for that midterm',
-        logType: 'task',
-        finished: false
-      }
-    }],
-    notes: [{
-      item: {
-        description: 'Enough about midterm',
-        logType: 'note'
-      }
-    }],
-    events: [],
-    reflection: [],
-    type: 'daily-log'
-  }
-  li.appendChild(searchItem)
-  searchResults.appendChild(li)
-  li2.appendChild(searchItem2)
-  searchResults.appendChild(li2)
   searchButton.addEventListener('click', (event) => {
     searchResults.innerHTML = ''
     getLogInfoAsJSON(inputField.value, radioDailyLog.checked ? 'daily-logs' : 'collections')

--- a/source/javascript/src/utils/Router.js
+++ b/source/javascript/src/utils/Router.js
@@ -61,6 +61,7 @@ class Router {
  */
 const ROUTES = {
   index: '/source/html/index.html',
+  search: '/source/html/search.html',
   collections: '/source/html/collection.html',
   'collection-edit': '/source/html/collection-edit.html',
   daily: '/source/html/daily.html',

--- a/source/javascript/src/weekly.js
+++ b/source/javascript/src/weekly.js
@@ -1,6 +1,6 @@
 import { IndexedDBWrapper } from './indexedDB/IndexedDBWrapper.js'
 import { DateConverter } from './utils/DateConverter.js'
-import { Router } from './utils/Router.js'
+import { Router, ROUTES } from './utils/Router.js'
 
 const weekly = document.getElementById('weekly-div')
 const monday = document.getElementById('Monday')
@@ -127,7 +127,7 @@ document.addEventListener('DOMContentLoaded', (event) => {
 })
 
 /**
- * @author Katherine Baker <klbaker@ucsd.edu> and Yuzi Lyu <>
+ * @author Katherine Baker <klbaker@ucsd.edu>, and Yuzi Lyu <>, Noah Teshima <nteshima@ucsd.edu>
  * @param {HTMLElement} targetElement div element that is a direct
  * child of the div with identifier #weekly-div. From this element, we
  * are able to
@@ -136,28 +136,13 @@ document.addEventListener('DOMContentLoaded', (event) => {
  */
 function appendNavLinks (targetElement, date) {
   const anchor = targetElement.querySelector('a')
-  anchor.dataset.unixTimestamp = date.getTime()
-  anchor.href = '/source/html/daily.html' // @TODO refactor with routing
-  // adjusts current_log in DB
   anchor.onclick = function (event) {
     event.preventDefault()
-    const wrapper = new IndexedDBWrapper('experimentalDB', 1)
-    const that = event
-
-    wrapper.transaction((event) => {
-      const db = event.target.result
-      const store = db.transaction(['currentLogStore'], 'readwrite').objectStore('currentLogStore')
-
-      const req = store.openCursor()
-      req.onsuccess = (e) => {
-        const cursor = e.target.result
-        if (cursor) {
-          cursor.value.current_log = that.target.dataset.unixTimestamp
-          cursor.update(cursor.value)
-        }
-      }
-    })
-    window.location.href = '/source/html/daily.html'
+    const params = new URLSearchParams()
+    params.append('timestamp', date.timestamp)
+    const url = new URL(ROUTES.daily, location.origin)
+    url.search = params
+    new Router(url).navigate()
   }
 }
 

--- a/source/models/mock_data.json
+++ b/source/models/mock_data.json
@@ -36,12 +36,12 @@
         "properties": {
           "date": {
             "type": "string",
-            "time": "1622752964489",
+            "time": "1623312720000",
             "description": "The date of the event."
           },
           "events": [
             {
-              "description": "February 28, 2022",
+              "description": "June 10, 2021",
               "logType": "event",
               "time": "1621718384658"
             }
@@ -65,12 +65,12 @@
         "properties": {
           "date": {
             "type": "string",
-            "time": "1646251200000",
+            "time": "1623485280000",
             "description": "The date of the event."
           },
           "events": [
             {
-              "description": "March 2, 2022",
+              "description": "June 12, 2021",
               "logType": "event",
               "time": "1621718384658"
             }
@@ -83,7 +83,7 @@
             "multipleOf": 1,
             "minimum": 0,
             "exclusiveMaximum": 100,
-            "value": 20,
+            "value": 40,
             "description": "Daily mood on a range of 0-99."
           }
         }
@@ -94,12 +94,12 @@
         "properties": {
           "date": {
             "type": "string",
-            "time": "1646510400000",
+            "time": "1625386080000",
             "description": "The date of the event."
           },
           "events": [
             {
-              "description": "March 5, 2022",
+              "description": "July 4, 2021",
               "logType": "event",
               "time": "1621718384658"
             }
@@ -112,7 +112,7 @@
             "multipleOf": 1,
             "minimum": 0,
             "exclusiveMaximum": 100,
-            "value": 20,
+            "value": 60,
             "description": "Daily mood on a range of 0-99."
           }
         }


### PR DESCRIPTION
Previously, we were using fields in local storage labeled `current_log` and `current_collection` in order to determine which entries to display at the navigation points for our site (from `weekly.html` to `daily.html`, `collection.html` to `collection-edit.html` etc.). However, this approach was problematic in the instance where users want to have multiple pages of our bullet journal open at once (`current_log` would be set to one of multiple daily logs or collections currently opened, causing all CRUD operations with indexedDB to incorrectly change entries in object storage). This PR reflections the integrated changes from the class `Router.js`, which uses query parameters instead to keep track of the information needed to display on every page. Resolves #321 