### PR TITLE
Changed order in which weekly view and daily log shows log items

### DIFF
--- a/source/javascript/src/components/WeeklyViewItem.js
+++ b/source/javascript/src/components/WeeklyViewItem.js
@@ -88,6 +88,13 @@ background: linear-gradient(335deg, rgba(247,240,63,1) 0%, rgba(254,255,156,1) 1
       // li.appendChild(reflectionItem)
       weekdayCol.appendChild(row)
     })
+    events.forEach((event, index) => {
+      const eventItem = this.getEntryToWeeklyView(event)
+      eventItem.shadowRoot.querySelector('button').style.display = 'none'
+      // li.appendChild(eventItem)
+      const row = this.makeRow(eventItem)
+      weekdayCol.appendChild(row)
+    })
     tasks.forEach((task, index) => {
       const taskItem = this.getEntryToWeeklyView(task)
       taskItem.shadowRoot.querySelector('button').style.display = 'none'
@@ -98,13 +105,6 @@ background: linear-gradient(335deg, rgba(247,240,63,1) 0%, rgba(254,255,156,1) 1
       const noteItem = this.getEntryToWeeklyView(notes)
       noteItem.shadowRoot.querySelector('button').style.display = 'none'
       const row = this.makeRow(noteItem)
-      weekdayCol.appendChild(row)
-    })
-    events.forEach((event, index) => {
-      const eventItem = this.getEntryToWeeklyView(event)
-      eventItem.shadowRoot.querySelector('button').style.display = 'none'
-      // li.appendChild(eventItem)
-      const row = this.makeRow(eventItem)
       weekdayCol.appendChild(row)
     })
   }

--- a/source/javascript/src/components/WeeklyViewItem.js
+++ b/source/javascript/src/components/WeeklyViewItem.js
@@ -81,6 +81,13 @@ background: linear-gradient(335deg, rgba(247,240,63,1) 0%, rgba(254,255,156,1) 1
     const reflection = this._entry.properties.reflection
     // console.log(reflection);
 
+    reflection.forEach((reflection, index) => {
+      const reflectionItem = this.getEntryToWeeklyView(reflection)
+      const row = this.makeRow(reflectionItem)
+      reflectionItem.shadowRoot.querySelector('button').style.display = 'none'
+      // li.appendChild(reflectionItem)
+      weekdayCol.appendChild(row)
+    })
     tasks.forEach((task, index) => {
       const taskItem = this.getEntryToWeeklyView(task)
       taskItem.shadowRoot.querySelector('button').style.display = 'none'
@@ -98,13 +105,6 @@ background: linear-gradient(335deg, rgba(247,240,63,1) 0%, rgba(254,255,156,1) 1
       eventItem.shadowRoot.querySelector('button').style.display = 'none'
       // li.appendChild(eventItem)
       const row = this.makeRow(eventItem)
-      weekdayCol.appendChild(row)
-    })
-    reflection.forEach((reflection, index) => {
-      const reflectionItem = this.getEntryToWeeklyView(reflection)
-      const row = this.makeRow(reflectionItem)
-      reflectionItem.shadowRoot.querySelector('button').style.display = 'none'
-      // li.appendChild(reflectionItem)
       weekdayCol.appendChild(row)
     })
   }


### PR DESCRIPTION
We updated the daily log and weekly view to show reflection data first. This is largely due to the fact that reflections are a good summary of each daily log entry for our bullet journal, and should consequently take priority when displaying what happened for each entry.