### PR TITLE
Added subtree push to `programming-docs` branch for documentation

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -25,5 +25,11 @@ jobs:
         with:
           node-version: 15.x
       - run: npm ci
-      - run: npm run build --if-present
       - run: npm run docs
+      - name: Deploy docs
+      - uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: programming-docs
+          build_dir: specs/programming_docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
For our programming docs, we are primarily interested in providing a branch where documentation can be viewed. We consequently decided to use subtree pushing to `programming-docs` with the generated documentation.